### PR TITLE
[WIP]: Update Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,18 +107,20 @@ pipeline {
           def config_path = '--env CONFIG_PATH=/usr/src/app/config';
           def db_host = '--env datastore__service__data_sources__default__adapter__server__host=db';
           def db_link = "--link ${db_container_id}:db";
-
+          
           server_image.inside("${node_env} ${junit_report_path} ${config_path} ${db_host} ${db_link}") {
 
+            def error_code_external;
+            def error_code_internal;
             def test_execution_script = 'node /usr/src/app/node_modules/.bin/mocha /usr/src/app/test/**/*.js --colors --reporter mocha-jenkins-reporter --exit'
 
             withEnv(['CONSUMER_API_ACCESS_TYPE=external']) {
-              def error_code_external = sh(script: "${test_execution_script}  > result_external.txt", returnStatus: true);
+              error_code_external = sh(script: "${test_execution_script}  > result_external.txt", returnStatus: true);
               testresults = sh(script: 'cat result_external.txt', returnStdout: true).trim();
             }
 
             withEnv(['CONSUMER_API_ACCESS_TYPE=internal']) {
-              def error_code_internal = sh(script: "${test_execution_script}  > result_internal.txt", returnStatus: true);
+              error_code_internal = sh(script: "${test_execution_script}  > result_internal.txt", returnStatus: true);
               testresults += sh(script: 'cat result_internal.txt', returnStdout: true).trim();
             }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,11 +112,15 @@ pipeline {
 
             def test_execution_script = 'node /usr/src/app/node_modules/.bin/mocha /usr/src/app/test/**/*.js --colors --reporter mocha-jenkins-reporter --exit'
 
-            error_code_external = sh(script: "CONSUMER_API_ACCESS_TYPE=external ${test_execution_script}  > result_external.txt", returnStatus: true);
-            testresults = sh(script: 'cat result_external.txt', returnStdout: true).trim();
+            withEnv(['CONSUMER_API_ACCESS_TYPE=external']) {
+              def error_code_external = sh(script: "${test_execution_script}  > result_external.txt", returnStatus: true);
+              testresults = sh(script: 'cat result_external.txt', returnStdout: true).trim();
+            }
 
-            error_code_internal = sh(script: "CONSUMER_API_ACCESS_TYPE=internal ${test_execution_script}  > result_internal.txt", returnStatus: true);
-            testresults += sh(script: 'cat result_internal.txt', returnStdout: true).trim();
+            withEnv(['CONSUMER_API_ACCESS_TYPE=internal']) {
+              def error_code_internal = sh(script: "${test_execution_script}  > result_internal.txt", returnStatus: true);
+              testresults += sh(script: 'cat result_internal.txt', returnStdout: true).trim();
+            }
 
             junit 'report.xml'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,7 +108,7 @@ pipeline {
           def db_host = '--env datastore__service__data_sources__default__adapter__server__host=db';
           def db_link = "--link ${db_container_id}:db";
 
-          server_image.inside("${node_env} ${consumer_api_access_type} ${junit_report_path} ${config_path} ${db_host} ${db_link}") {
+          server_image.inside("${node_env} ${junit_report_path} ${config_path} ${db_host} ${db_link}") {
 
             def test_execution_script = 'node /usr/src/app/node_modules/.bin/mocha /usr/src/app/test/**/*.js --colors --reporter mocha-jenkins-reporter --exit'
 


### PR DESCRIPTION
Closes #27 

## What did you change?

This updates the Jenkinsfile for the ConsumerApiMeta setup, so that Jenkins can run the integrationtests against an external and an internal process engine.

The results of both test runs are then concatenated to get an overall result.

@Paulomart 
This change was introduced with this PR: #25 
The tests are now run twice; once for each scenario.
The type of the test scenario is determined by an environment variable named `CONSUMER_API_ACCESS_TYPE`.

## How can others test the changes?

Check Jenkins Build.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [ ] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
