### PR TITLE
Feature/remove consumer api client addict ioc implementation

### DIFF
--- a/_integration_tests/index.js
+++ b/_integration_tests/index.js
@@ -33,7 +33,6 @@ const iocModuleNames = [
   '@essential-projects/routing',
   '@essential-projects/timing',
   '@essential-projects/validation',
-  '@process-engine/consumer_api_client',
   '@process-engine/consumer_api_core',
   '@process-engine/consumer_api_http',
   '@process-engine/process_engine',
@@ -63,14 +62,14 @@ async function start() {
     for (const iocModule of iocModules) {
       iocModule.registerInContainer(container);
     }
-  
+
     container.validateDependencies();
-    
+
     const appPath = path.resolve(__dirname);
     const bootstrapper = await container.resolveAsync('AppBootstrapper', [appPath]);
 
     logger.info('Bootstrapper started.');
-  
+
     await bootstrapper.start();
   } catch (error) {
     logger.error('Failed to start bootstrapper!', error);

--- a/_integration_tests/ioc_module.js
+++ b/_integration_tests/ioc_module.js
@@ -3,16 +3,26 @@
 const fs = require('fs');
 const path = require('path');
 
-const ConsumerApiClientService = require('@process-engine/consumer_api_client').ConsumerApiClientService;
+const {
+  ConsumerApiClientService,
+  ExternalAccessor,
+  InternalAccessor,
+} = require('@process-engine/consumer_api_client');
 
 const registerInContainer = (container) => {
 
   const accessConsumerApiInternally = process.env.CONSUMER_API_ACCESS_TYPE === 'internal';
 
   if (accessConsumerApiInternally) {
+    container.register('ConsumerApiInternalAccessor', InternalAccessor)
+      .dependencies('ConsumerApiService');
+
     container.register('ConsumerApiClientService', ConsumerApiClientService)
       .dependencies('ConsumerApiInternalAccessor');
   } else {
+    container.register('ConsumerApiExternalAccessor', ExternalAccessor)
+      .dependencies('HttpService');
+
     container.register('ConsumerApiClientService', ConsumerApiClientService)
       .dependencies('ConsumerApiExternalAccessor');
   }

--- a/_integration_tests/package.json
+++ b/_integration_tests/package.json
@@ -45,7 +45,7 @@
     "@essential-projects/services": "^2.0.0",
     "@essential-projects/timing": "^2.0.0",
     "@essential-projects/validation": "^2.0.0",
-    "@process-engine/consumer_api_client": "^0.10.0",
+    "@process-engine/consumer_api_client": "feature~remove_consumer_api_client_addict-ioc_implementation",
     "@process-engine/consumer_api_contracts": "^0.11.0",
     "@process-engine/consumer_api_core": "^0.12.1",
     "@process-engine/consumer_api_http": "^0.9.1",

--- a/_integration_tests/src/test_fixture_provider.ts
+++ b/_integration_tests/src/test_fixture_provider.ts
@@ -37,7 +37,6 @@ const iocModuleNames: Array<string> = [
   '@essential-projects/routing',
   '@essential-projects/timing',
   '@essential-projects/validation',
-  '@process-engine/consumer_api_client',
   '@process-engine/consumer_api_core',
   '@process-engine/consumer_api_http',
   '@process-engine/process_engine',


### PR DESCRIPTION
## What did you change?

Implements the changes from https://github.com/process-engine/consumer_api_client/pull/14

Ensures that the integrationtests can still work, by adding custom ioc registrations for the consumer api client to the `ioc_module`.

## How can others test the changes?

It's an internal change. All tests should run as before.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
