### PR TITLE
👷🐛 Fix Slack-Report generation after Jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,20 +27,27 @@ def cleanup_docker() {
 }
 
 def slack_send_summary(testlog, test_failed) {
-  def cleaned_string = testlog.replace('\n', '\\n').replace('"', '\\"');
-  def passing = sh(script: "echo \"${cleaned_string}\" | grep passing || echo \"0 passing\"", returnStdout: true).trim();
-  def failing = sh(script: "echo \"${cleaned_string}\" | grep failing || echo \"0 failing\"", returnStdout: true).trim();
-  def pending = sh(script: "echo \"${cleaned_string}\" | grep pending || echo \"0 pending\"", returnStdout: true).trim();
+  def passing_regex = /\d+ passing/;
+  def failing_regex = /\d+ failing/;
+  def pending_regex = /\d+ pending/;
+
+  def passing_matcher = testlog =~ passing_regex;
+  def failing_matcher = testlog =~ failing_regex;
+  def pending_matcher = testlog =~ pending_regex;
+
+  def passing = passing_matcher.count > 0 ? passing_matcher[0] : '0 passing';
+  def failing = failing_matcher.count > 0 ? failing_matcher[0] : '0 failing';
+  def pending = pending_matcher.count > 0 ? pending_matcher[0] : '0 pending';
 
   def color_string     =  '"color":"good"';
   def markdown_string  =  '"mrkdwn_in":["text","title"]';
-  def title_string     =  "\"title\":\":white_check_mark: Consumer tests for ${env.BRANCH_NAME} succeeded!\"";
+  def title_string     =  "\"title\":\":white_check_mark: Process Engine Runtime Integration Tests for ${BRANCH_NAME} Succeeded!\"";
   def result_string    =  "\"text\":\"${passing}\\n${failing}\\n${pending}\"";
   def action_string    =  "\"actions\":[{\"name\":\"open_jenkins\",\"type\":\"button\",\"text\":\"Open this run\",\"url\":\"${RUN_DISPLAY_URL}\"}]";
 
   if (test_failed == true) {
     color_string = '"color":"danger"';
-    title_string =  "\"title\":\":boom: Consumer tests for ${env.BRANCH_NAME} failed!\"";
+    title_string =  "\"title\":\":boom: Process Engine Runtime Integration Tests for ${BRANCH_NAME} Failed!\"";
   }
 
   slackSend(attachments: "[{$color_string, $title_string, $markdown_string, $result_string, $action_string}]");

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,12 +51,6 @@ def slack_send_summary(testlog, test_failed) {
     title_string =  "\"title\":\":boom: Consumer API Integration Tests for ${BRANCH_NAME} Failed!\"";
   }
 
-  println(color_string);
-  println(title_string);
-  println(markdown_string);
-  println(result_string);
-  println(action_string);
-
   slackSend(attachments: "[{$color_string, $title_string, $markdown_string, $result_string, $action_string}]");
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,9 +129,7 @@ pipeline {
           println(testresults);
           // Failure to send the slack message should not result in build failure.
           try {
-            echo "Sending test summary to slack";
             slack_send_summary(testresults, test_failed);
-            echo "Sending test log to slack";
             slack_send_testlog(testresults);
           } catch (Exception error) {
             echo "Failed to send slack report: $error";

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,13 +41,13 @@ def slack_send_summary(testlog, test_failed) {
 
   def color_string     =  '"color":"good"';
   def markdown_string  =  '"mrkdwn_in":["text","title"]';
-  def title_string     =  "\"title\":\":white_check_mark: Process Engine Runtime Integration Tests for ${BRANCH_NAME} Succeeded!\"";
+  def title_string     =  "\"title\":\":white_check_mark: Consumer API Integration Tests for ${BRANCH_NAME} Succeeded!\"";
   def result_string    =  "\"text\":\"${passing}\\n${failing}\\n${pending}\"";
   def action_string    =  "\"actions\":[{\"name\":\"open_jenkins\",\"type\":\"button\",\"text\":\"Open this run\",\"url\":\"${RUN_DISPLAY_URL}\"}]";
 
   if (test_failed == true) {
     color_string = '"color":"danger"';
-    title_string =  "\"title\":\":boom: Process Engine Runtime Integration Tests for ${BRANCH_NAME} Failed!\"";
+    title_string =  "\"title\":\":boom: Consumer API Integration Tests for ${BRANCH_NAME} Failed!\"";
   }
 
   slackSend(attachments: "[{$color_string, $title_string, $markdown_string, $result_string, $action_string}]");

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,7 +128,9 @@ pipeline {
           println(testresults);
           // Failure to send the slack message should not result in build failure.
           try {
+            echo "Sending test summary to slack";
             slack_send_summary(testresults, test_failed);
+            echo "Sending test log to slack";
             slack_send_testlog(testresults);
           } catch (Exception error) {
             echo "Failed to send slack report: $error";

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,12 @@ def slack_send_summary(testlog, test_failed) {
     title_string =  "\"title\":\":boom: Consumer API Integration Tests for ${BRANCH_NAME} Failed!\"";
   }
 
+  println(color_string);
+  println(title_string);
+  println(markdown_string);
+  println(result_string);
+  println(action_string);
+
   slackSend(attachments: "[{$color_string, $title_string, $markdown_string, $result_string, $action_string}]");
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ def cleanup_docker() {
   sh(script: "docker volume prune --force");
 }
 
+@NonCPS
 def slack_send_summary(testlog, test_failed) {
   def passing_regex = /\d+ passing/;
   def failing_regex = /\d+ failing/;


### PR DESCRIPTION
**Changes:**

Fix the Slack-Report generation for Jenkins-Builds.
The Report will now be properly formatted, as it is with the other repositories.

Note: 
The `@NonCPS` decorator is necessary because of this issue:
https://stackoverflow.com/questions/40454558/jenkins-pipeline-java-io-notserializableexception-java-util-regex-matcher-error

PR: #68

## How can others test the changes?

Run some builds on Jenkins.

Before:

![bildschirmfoto 2019-02-15 um 09 53 56](https://user-images.githubusercontent.com/15343316/52845526-a5efd080-3107-11e9-81cb-39ffbf01f775.png)

After:

![bildschirmfoto 2019-02-15 um 09 54 01](https://user-images.githubusercontent.com/15343316/52845531-a9835780-3107-11e9-8322-6edad6429c71.png)

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).