### PR TITLE
✅ Cleanup databases after each test run

### DIFF
--- a/_integration_tests/src/fixture_providers/test_fixture_provider.ts
+++ b/_integration_tests/src/fixture_providers/test_fixture_provider.ts
@@ -12,7 +12,7 @@ import {HttpExtension} from '@essential-projects/http_extension';
 import {IIdentity, TokenBody} from '@essential-projects/iam_contracts';
 
 import {IConsumerApiClient} from '@process-engine/consumer_api_contracts';
-import {IProcessModelService as IProcessModelUseCases} from '@process-engine/process_model.contracts';
+import {IProcessModelUseCases} from '@process-engine/process_model.contracts';
 
 import {initializeBootstrapper} from './setup_ioc_container';
 
@@ -63,6 +63,7 @@ export class TestFixtureProvider {
 
   public async tearDown(): Promise<void> {
     const httpExtension = await this.container.resolveAsync<HttpExtension>('HttpExtension');
+    await this.clearDatabases();
     await httpExtension.close();
     await this.bootstrapper.stop();
   }
@@ -111,7 +112,7 @@ export class TestFixtureProvider {
 
     for (const processModel of processModels) {
       logger.info(`Removing ProcessModel ${processModel.id} and all related data`);
-      await this.processModelUseCases.deleteProcessDefinitionById(processModel.id);
+      await this.processModelUseCases.deleteProcessModel(this.identities.superAdmin, processModel.id);
     }
   }
 

--- a/_integration_tests/src/fixture_providers/test_fixture_provider.ts
+++ b/_integration_tests/src/fixture_providers/test_fixture_provider.ts
@@ -24,6 +24,7 @@ export type IdentityCollection = {
   userWithAccessToSubLaneC: IIdentity;
   userWithAccessToLaneA: IIdentity;
   userWithNoAccessToLaneA: IIdentity;
+  superAdmin: IIdentity;
 };
 
 export class TestFixtureProvider {
@@ -104,6 +105,16 @@ export class TestFixtureProvider {
     return path.join(rootDirPath, bpmnDirectoryName);
   }
 
+  public async clearDatabases(): Promise<void> {
+
+    const processModels = await this.processModelUseCases.getProcessModels(this.identities.superAdmin);
+
+    for (const processModel of processModels) {
+      logger.info(`Removing ProcessModel ${processModel.id} and all related data`);
+      await this.processModelUseCases.deleteProcessDefinitionById(processModel.id);
+    }
+  }
+
   private async initializeBootstrapper(): Promise<void> {
 
     try {
@@ -130,6 +141,7 @@ export class TestFixtureProvider {
       userWithAccessToSubLaneC: await this.createIdentity('userWithAccessToSubLaneC'),
       userWithAccessToLaneA: await this.createIdentity('userWithAccessToLaneA'),
       userWithNoAccessToLaneA: await this.createIdentity('userWithNoAccessToLaneA'),
+      superAdmin: await this.createIdentity('superAdmin'),
     };
   }
 

--- a/_integration_tests/src/fixture_providers/test_fixture_provider.ts
+++ b/_integration_tests/src/fixture_providers/test_fixture_provider.ts
@@ -62,8 +62,9 @@ export class TestFixtureProvider {
   }
 
   public async tearDown(): Promise<void> {
-    const httpExtension = await this.container.resolveAsync<HttpExtension>('HttpExtension');
     await this.clearDatabases();
+
+    const httpExtension = await this.container.resolveAsync<HttpExtension>('HttpExtension');
     await httpExtension.close();
     await this.bootstrapper.stop();
   }

--- a/_integration_tests/test/empty_activities/finish_empty_task.js
+++ b/_integration_tests/test/empty_activities/finish_empty_task.js
@@ -28,7 +28,6 @@ describe(`Consumer API: ${testCase}`, () => {
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -187,18 +186,4 @@ describe(`Consumer API: ${testCase}`, () => {
       should(error.code).be.match(expectedErrorCode);
     }
   });
-
-  async function cleanup() {
-
-    return new Promise(async (resolve, reject) => {
-      const processInstanceId = emptyActivityForBadPathTests.processInstanceId;
-      const emptyActivityId = emptyActivityForBadPathTests.flowNodeInstanceId;
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(emptyActivityForBadPathTests.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishEmptyActivity(defaultIdentity, processInstanceId, emptyActivityForBadPathTests.correlationId, emptyActivityId);
-    });
-  }
 });

--- a/_integration_tests/test/empty_activities/get_waiting_for_correlation.js
+++ b/_integration_tests/test/empty_activities/get_waiting_for_correlation.js
@@ -96,8 +96,6 @@ describe('ConsumerAPI:   GET  ->  /correlations/:correlation_id/empty_activities
     should(emptyActivity).have.property('tokenPayload');
     should(emptyActivity).not.have.property('processInstanceOwner');
     should(emptyActivity).not.have.property('identity');
-
-    await cleanup(emptyActivity);
   });
 
   it('should return a list of EmptyActivities from a call activity, by the given correlationId through the ConsumerAPI', async () => {
@@ -139,7 +137,6 @@ describe('ConsumerAPI:   GET  ->  /correlations/:correlation_id/empty_activities
       const result = await processInstanceHandler.startProcessInstanceAndReturnResult(processModelIdNoEmptyActivities);
       await processInstanceHandler.waitForProcessInstanceToReachSuspendedTask(result.correlationId, processModelIdNoEmptyActivities);
 
-      // Wait for the ProcessInstance to finish, so it won't interfere with follow-up tests.
       processInstanceHandler.waitForProcessWithInstanceIdToEnd(result.processInstanceId, resolve);
 
       const emptyActivityList = await testFixtureProvider
@@ -166,17 +163,4 @@ describe('ConsumerAPI:   GET  ->  /correlations/:correlation_id/empty_activities
     should(emptyActivityList.emptyActivities).be.instanceOf(Array);
     should(emptyActivityList.emptyActivities.length).be.equal(0);
   });
-
-  async function cleanup(emptyActivity) {
-    return new Promise(async (resolve, reject) => {
-      const processInstanceId = emptyActivity.processInstanceId;
-      const emptyActivityId = emptyActivity.flowNodeInstanceId;
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(emptyActivity.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishEmptyActivity(defaultIdentity, processInstanceId, emptyActivity.correlationId, emptyActivityId);
-    });
-  }
 });

--- a/_integration_tests/test/empty_activities/get_waiting_for_identity.js
+++ b/_integration_tests/test/empty_activities/get_waiting_for_identity.js
@@ -32,7 +32,6 @@ describe('ConsumerAPI:   GET  ->  /empty_activities/own', () => {
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -89,18 +88,4 @@ describe('ConsumerAPI:   GET  ->  /empty_activities/own', () => {
       should(error.code).be.match(expectedErrorCode);
     }
   });
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-      const emptyActivityCorrelation = emptyActivityToCleanupAfterTest.correlationId;
-      const processInstanceId = emptyActivityToCleanupAfterTest.processInstanceId;
-      const emptyActivityId = emptyActivityToCleanupAfterTest.flowNodeInstanceId;
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(emptyActivityToCleanupAfterTest.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishEmptyActivity(defaultIdentity, processInstanceId, emptyActivityCorrelation, emptyActivityId);
-    });
-  }
 });

--- a/_integration_tests/test/empty_activities/get_waiting_for_process_model.js
+++ b/_integration_tests/test/empty_activities/get_waiting_for_process_model.js
@@ -40,7 +40,6 @@ describe('Consumer API:   GET  ->  /process_models/:process_model_id/empty_activ
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -139,18 +138,4 @@ describe('Consumer API:   GET  ->  /process_models/:process_model_id/empty_activ
       should(error.code).be.match(expectedErrorCode);
     }
   });
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-      const processInstanceId = emptyActivityToFinishAfterTest.processInstanceId;
-      const emptyActivityId = emptyActivityToFinishAfterTest.flowNodeInstanceId;
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(emptyActivityToFinishAfterTest.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishEmptyActivity(defaultIdentity, processInstanceId, emptyActivityToFinishAfterTest.correlationId, emptyActivityId);
-    });
-  }
-
 });

--- a/_integration_tests/test/empty_activities/get_waiting_for_process_model_in_correlation.js
+++ b/_integration_tests/test/empty_activities/get_waiting_for_process_model_in_correlation.js
@@ -36,7 +36,6 @@ describe(`Consumer API: ${testCase}`, () => {
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -146,17 +145,4 @@ describe(`Consumer API: ${testCase}`, () => {
       should(error.code).be.match(expectedErrorCode);
     }
   });
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-      const processInstanceId = emptyActivityToFinishAfterTest.processInstanceId;
-      const userTaskId = emptyActivityToFinishAfterTest.flowNodeInstanceId;
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(emptyActivityToFinishAfterTest.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishEmptyActivity(defaultIdentity, processInstanceId, emptyActivityToFinishAfterTest.correlationId, userTaskId);
-    });
-  }
 });

--- a/_integration_tests/test/events/get_correlation_events.js
+++ b/_integration_tests/test/events/get_correlation_events.js
@@ -33,7 +33,6 @@ describe('Consumer API:   GET  ->  /correlations/:correlation_id/events', () => 
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -105,14 +104,4 @@ describe('Consumer API:   GET  ->  /correlations/:correlation_id/events', () => 
       should(error.message).be.match(expectedErrorMessage);
     }
   });
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .triggerSignalEvent(defaultIdentity, eventNameToTriggerAfterTest, {});
-    });
-  }
 });

--- a/_integration_tests/test/events/get_correlation_process_model_events.js
+++ b/_integration_tests/test/events/get_correlation_process_model_events.js
@@ -33,7 +33,6 @@ describe('Consumer API GET  ->  /process_models/:process_model_id/correlations/:
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -122,15 +121,4 @@ describe('Consumer API GET  ->  /process_models/:process_model_id/correlations/:
       should(error.message).be.match(expectedErrorMessage);
     }
   });
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .triggerSignalEvent(defaultIdentity, eventNameToTriggerAfterTest, {});
-    });
-  }
-
 });

--- a/_integration_tests/test/events/get_process_model_events.js
+++ b/_integration_tests/test/events/get_process_model_events.js
@@ -33,7 +33,6 @@ describe('Consumer API:   GET  ->  /process_models/:process_model_id/events', ()
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -110,15 +109,4 @@ describe('Consumer API:   GET  ->  /process_models/:process_model_id/events', ()
       should(error.message).be.match(expectedErrorMessage);
     }
   });
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .triggerSignalEvent(defaultIdentity, eventNameToTriggerAfterTest, {});
-    });
-  }
-
 });

--- a/_integration_tests/test/external_tasks/extend_lock.js
+++ b/_integration_tests/test/external_tasks/extend_lock.js
@@ -38,7 +38,6 @@ describe('Consumer API:   POST  ->  /external_tasks/:external_task_id/extend_loc
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -172,15 +171,4 @@ describe('Consumer API:   POST  ->  /external_tasks/:external_task_id/extend_loc
 
     should(lockExpirationTimeIsLongerThanBefore).be.true();
   }
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(externalTask.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishExternalTask(defaultIdentity, workerId, externalTask.id, {});
-    });
-  }
-
 });

--- a/_integration_tests/test/external_tasks/fetch_and_lock.js
+++ b/_integration_tests/test/external_tasks/fetch_and_lock.js
@@ -58,8 +58,6 @@ describe('Consumer API:   POST  ->  /external_tasks/fetch_and_lock', () => {
 
     const externalTask = availableExternalTasks[0];
 
-    await cleanup(externalTask);
-
     should(externalTask.workerId).be.equal(workerId);
     should(externalTask.topic).be.equal(topicName);
     should(externalTask.state).be.equal('pending');
@@ -93,8 +91,6 @@ describe('Consumer API:   POST  ->  /external_tasks/fetch_and_lock', () => {
     const externalTask = availableExternalTasks[0];
     console.log(externalTask);
     should(externalTask.payload.currentToken).have.property('test_type');
-
-    await cleanup(externalTask);
 
     should(externalTask.payload).have.property('testProperty');
     should(externalTask.payload.testProperty).be.equal('Test');
@@ -133,22 +129,10 @@ describe('Consumer API:   POST  ->  /external_tasks/fetch_and_lock', () => {
   });
 
   async function createWaitingExternalTask(testType, targetTopicName) {
-
     const correlationId = uuid.v4();
 
     processInstanceHandler.startProcessInstanceAndReturnCorrelationId(processModelId, correlationId, {test_type: testType});
 
     await processInstanceHandler.waitForExternalTaskToBeCreated(targetTopicName);
   }
-
-  async function cleanup(externalTask) {
-    return new Promise(async (resolve, reject) => {
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(externalTask.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishExternalTask(defaultIdentity, workerId, externalTask.id, {});
-    });
-  }
-
 });

--- a/_integration_tests/test/external_tasks/finish_task.js
+++ b/_integration_tests/test/external_tasks/finish_task.js
@@ -39,7 +39,6 @@ describe('Consumer API:   POST  ->  /external_tasks/:external_task_id/finish', (
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -181,15 +180,4 @@ describe('Consumer API:   POST  ->  /external_tasks/:external_task_id/finish', (
     should(externalTask).have.property('payload');
     should(externalTask).have.property('createdAt');
   }
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(externalTaskBadPathTests.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishExternalTask(defaultIdentity, workerId, externalTaskBadPathTests.id, samplePayload);
-    });
-  }
-
 });

--- a/_integration_tests/test/external_tasks/handle_bpmn_error.js
+++ b/_integration_tests/test/external_tasks/handle_bpmn_error.js
@@ -37,7 +37,6 @@ describe('Consumer API:   POST  ->  /external_tasks/:external_task_id/handle_bpm
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -173,15 +172,4 @@ describe('Consumer API:   POST  ->  /external_tasks/:external_task_id/handle_bpm
     should(externalTask).have.property('payload');
     should(externalTask).have.property('createdAt');
   }
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(externalTaskBadPathTests.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishExternalTask(defaultIdentity, workerId, externalTaskBadPathTests.id, {});
-    });
-  }
-
 });

--- a/_integration_tests/test/external_tasks/handle_service_error.js
+++ b/_integration_tests/test/external_tasks/handle_service_error.js
@@ -38,7 +38,6 @@ describe('Consumer API:   POST  ->  /external_tasks/:external_task_id/handle_ser
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -175,15 +174,4 @@ describe('Consumer API:   POST  ->  /external_tasks/:external_task_id/handle_ser
     should(externalTask).have.property('payload');
     should(externalTask).have.property('createdAt');
   }
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(externalTaskBadPathTests.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishExternalTask(defaultIdentity, workerId, externalTaskBadPathTests.id, {});
-    });
-  }
-
 });

--- a/_integration_tests/test/manual_tasks/finish_manual_tasks.js
+++ b/_integration_tests/test/manual_tasks/finish_manual_tasks.js
@@ -28,7 +28,6 @@ describe(`Consumer API: ${testCase}`, () => {
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -187,18 +186,4 @@ describe(`Consumer API: ${testCase}`, () => {
       should(error.code).be.match(expectedErrorCode);
     }
   });
-
-  async function cleanup() {
-
-    return new Promise(async (resolve, reject) => {
-      const processInstanceId = manualTaskForBadPathTests.processInstanceId;
-      const manualTaskId = manualTaskForBadPathTests.flowNodeInstanceId;
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(manualTaskForBadPathTests.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishManualTask(defaultIdentity, processInstanceId, manualTaskForBadPathTests.correlationId, manualTaskId);
-    });
-  }
 });

--- a/_integration_tests/test/manual_tasks/get_waiting_for_correlation.js
+++ b/_integration_tests/test/manual_tasks/get_waiting_for_correlation.js
@@ -96,8 +96,6 @@ describe('ConsumerAPI:   GET  ->  /correlations/:correlation_id/manual_tasks', (
     should(manualTask).have.property('tokenPayload');
     should(manualTask).not.have.property('processInstanceOwner');
     should(manualTask).not.have.property('identity');
-
-    await cleanup(manualTask);
   });
 
   it('should return a list of ManualTasks from a call activity, by the given correlationId through the ConsumerAPI', async () => {
@@ -166,17 +164,4 @@ describe('ConsumerAPI:   GET  ->  /correlations/:correlation_id/manual_tasks', (
     should(manualTaskList.manualTasks).be.instanceOf(Array);
     should(manualTaskList.manualTasks.length).be.equal(0);
   });
-
-  async function cleanup(manualTask) {
-    return new Promise(async (resolve, reject) => {
-      const processInstanceId = manualTask.processInstanceId;
-      const manualTaskId = manualTask.flowNodeInstanceId;
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(manualTask.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishManualTask(defaultIdentity, processInstanceId, manualTask.correlationId, manualTaskId);
-    });
-  }
 });

--- a/_integration_tests/test/manual_tasks/get_waiting_for_identity.js
+++ b/_integration_tests/test/manual_tasks/get_waiting_for_identity.js
@@ -32,7 +32,6 @@ describe('ConsumerAPI:   GET  ->  /manual_tasks/own', () => {
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -89,18 +88,4 @@ describe('ConsumerAPI:   GET  ->  /manual_tasks/own', () => {
       should(error.code).be.match(expectedErrorCode);
     }
   });
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-      const manualTaskCorrelation = manualTaskToCleanupAfterTest.correlationId;
-      const processInstanceId = manualTaskToCleanupAfterTest.processInstanceId;
-      const manualTaskId = manualTaskToCleanupAfterTest.flowNodeInstanceId;
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(manualTaskToCleanupAfterTest.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishManualTask(defaultIdentity, processInstanceId, manualTaskCorrelation, manualTaskId);
-    });
-  }
 });

--- a/_integration_tests/test/manual_tasks/get_waiting_for_process_model.js
+++ b/_integration_tests/test/manual_tasks/get_waiting_for_process_model.js
@@ -40,7 +40,6 @@ describe('Consumer API:   GET  ->  /process_models/:process_model_id/manual_task
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -139,18 +138,4 @@ describe('Consumer API:   GET  ->  /process_models/:process_model_id/manual_task
       should(error.code).be.match(expectedErrorCode);
     }
   });
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-      const processInstanceId = manualTaskToFinishAfterTest.processInstanceId;
-      const manualTaskId = manualTaskToFinishAfterTest.flowNodeInstanceId;
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(manualTaskToFinishAfterTest.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishManualTask(defaultIdentity, processInstanceId, manualTaskToFinishAfterTest.correlationId, manualTaskId);
-    });
-  }
-
 });

--- a/_integration_tests/test/manual_tasks/get_waiting_for_process_model_in_correlation.js
+++ b/_integration_tests/test/manual_tasks/get_waiting_for_process_model_in_correlation.js
@@ -36,7 +36,6 @@ describe(`Consumer API: ${testCase}`, () => {
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -146,17 +145,4 @@ describe(`Consumer API: ${testCase}`, () => {
       should(error.code).be.match(expectedErrorCode);
     }
   });
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-      const processInstanceId = manualTaskToFinishAfterTest.processInstanceId;
-      const userTaskId = manualTaskToFinishAfterTest.flowNodeInstanceId;
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(manualTaskToFinishAfterTest.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishManualTask(defaultIdentity, processInstanceId, manualTaskToFinishAfterTest.correlationId, userTaskId);
-    });
-  }
 });

--- a/_integration_tests/test/process_instances/get_running_instances_for_identity.js
+++ b/_integration_tests/test/process_instances/get_running_instances_for_identity.js
@@ -35,7 +35,6 @@ describe('ConsumerAPI:   GET  ->  /process_instances/own', () => {
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -95,32 +94,4 @@ describe('ConsumerAPI:   GET  ->  /process_instances/own', () => {
       should(error.message).be.match(expectedErrorMessage);
     }
   });
-
-  async function cleanup() {
-
-    const userTaskList = await testFixtureProvider
-      .consumerApiClient
-      .getUserTasksForProcessModelInCorrelation(defaultIdentity, processModelId, correlationId);
-
-    for (const userTask of userTaskList.userTasks) {
-      await finishUserTaskAndWaitForProcessInstanceToEnd(userTask);
-    }
-  }
-
-  async function finishUserTaskAndWaitForProcessInstanceToEnd(userTask) {
-
-    await new Promise(async (resolve, reject) => {
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(userTask.processInstanceId, resolve);
-
-      const userTaskInput = {
-        formFields: {
-          Sample_Form_Field: 'Hello',
-        },
-      };
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishUserTask(defaultIdentity, userTask.processInstanceId, userTask.correlationId, userTask.flowNodeInstanceId, userTaskInput);
-    });
-  }
 });

--- a/_integration_tests/test/user_tasks/finish_user_task.js
+++ b/_integration_tests/test/user_tasks/finish_user_task.js
@@ -28,7 +28,6 @@ describe(`Consumer API: ${testCase}`, () => {
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -297,23 +296,4 @@ describe(`Consumer API: ${testCase}`, () => {
       should(error.code).be.match(expectedErrorCode);
     }
   });
-
-  async function cleanup() {
-
-    return new Promise(async (resolve, reject) => {
-      const processInstanceId = userTaskForBadPathTests.processInstanceId;
-      const userTaskId = userTaskForBadPathTests.flowNodeInstanceId;
-      const userTaskResult = {
-        formFields: {
-          Form_XGSVBgio: true,
-        },
-      };
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(userTaskForBadPathTests.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishUserTask(defaultIdentity, processInstanceId, userTaskForBadPathTests.correlationId, userTaskId, userTaskResult);
-    });
-  }
 });

--- a/_integration_tests/test/user_tasks/get_waiting_for_correlation.js
+++ b/_integration_tests/test/user_tasks/get_waiting_for_correlation.js
@@ -164,7 +164,6 @@ describe('ConsumerAPI:   GET  ->  /correlations/:correlation_id/user_tasks', () 
         .consumerApiClient
         .getUserTasksForCorrelation(defaultIdentity, result.correlationId);
 
-      console.log(userTaskList);
 
       should(userTaskList).have.property('userTasks');
       should(userTaskList.userTasks).be.instanceOf(Array);

--- a/_integration_tests/test/user_tasks/get_waiting_for_correlation.js
+++ b/_integration_tests/test/user_tasks/get_waiting_for_correlation.js
@@ -108,8 +108,6 @@ describe('ConsumerAPI:   GET  ->  /correlations/:correlation_id/user_tasks', () 
     should(formField).have.property('enumValues');
     should(formField).have.property('label');
     should(formField).have.property('defaultValue');
-
-    await cleanup(userTask);
   });
 
   it('should return a list of UserTasks from a call activity, by the given correlationId through the ConsumerAPI', async () => {
@@ -164,7 +162,9 @@ describe('ConsumerAPI:   GET  ->  /correlations/:correlation_id/user_tasks', () 
 
       const userTaskList = await testFixtureProvider
         .consumerApiClient
-        .getUserTasksForCorrelation(defaultIdentity, correlationId);
+        .getUserTasksForCorrelation(defaultIdentity, result.correlationId);
+
+      console.log(userTaskList);
 
       should(userTaskList).have.property('userTasks');
       should(userTaskList.userTasks).be.instanceOf(Array);
@@ -186,23 +186,4 @@ describe('ConsumerAPI:   GET  ->  /correlations/:correlation_id/user_tasks', () 
     should(userTaskList.userTasks).be.instanceOf(Array);
     should(userTaskList.userTasks.length).be.equal(0);
   });
-
-  async function cleanup(userTaskToFinishAfterTest) {
-
-    return new Promise(async (resolve, reject) => {
-      const processInstanceId = userTaskToFinishAfterTest.processInstanceId;
-      const userTaskId = userTaskToFinishAfterTest.flowNodeInstanceId;
-      const userTaskResult = {
-        formFields: {
-          Form_XGSVBgio: true,
-        },
-      };
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(userTaskToFinishAfterTest.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishUserTask(defaultIdentity, processInstanceId, userTaskToFinishAfterTest.correlationId, userTaskId, userTaskResult);
-    });
-  }
 });

--- a/_integration_tests/test/user_tasks/get_waiting_for_identity.js
+++ b/_integration_tests/test/user_tasks/get_waiting_for_identity.js
@@ -32,7 +32,6 @@ describe('ConsumerAPI:   GET  ->  /user_tasks/own', () => {
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -89,17 +88,4 @@ describe('ConsumerAPI:   GET  ->  /user_tasks/own', () => {
       should(error.message).be.match(expectedErrorMessage);
     }
   });
-
-  async function cleanup() {
-    return new Promise(async (resolve, reject) => {
-      const processInstanceId = userTaskToCleanupAfterTest.processInstanceId;
-      const userTaskId = userTaskToCleanupAfterTest.flowNodeInstanceId;
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(userTaskToCleanupAfterTest.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishUserTask(defaultIdentity, processInstanceId, correlationId, userTaskId);
-    });
-  }
 });

--- a/_integration_tests/test/user_tasks/get_waiting_for_process_model.js
+++ b/_integration_tests/test/user_tasks/get_waiting_for_process_model.js
@@ -40,7 +40,6 @@ describe('Consumer API:   GET  ->  /process_models/:process_model_id/userTasks',
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -156,23 +155,4 @@ describe('Consumer API:   GET  ->  /process_models/:process_model_id/userTasks',
       should(error.message).be.match(expectedErrorMessage);
     }
   });
-
-  async function cleanup() {
-
-    return new Promise(async (resolve, reject) => {
-      const processInstanceId = userTaskToFinishAfterTest.processInstanceId;
-      const userTaskId = userTaskToFinishAfterTest.flowNodeInstanceId;
-      const userTaskResult = {
-        formFields: {
-          Form_XGSVBgio: true,
-        },
-      };
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(userTaskToFinishAfterTest.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishUserTask(defaultIdentity, processInstanceId, userTaskToFinishAfterTest.correlationId, userTaskId, userTaskResult);
-    });
-  }
 });

--- a/_integration_tests/test/user_tasks/get_waiting_for_process_model_in_correlation.js
+++ b/_integration_tests/test/user_tasks/get_waiting_for_process_model_in_correlation.js
@@ -36,7 +36,6 @@ describe(`Consumer API: ${testCase}`, () => {
   });
 
   after(async () => {
-    await cleanup();
     await testFixtureProvider.tearDown();
   });
 
@@ -158,24 +157,4 @@ describe(`Consumer API: ${testCase}`, () => {
       should(error.message).be.match(expectedErrorMessage);
     }
   });
-
-  async function cleanup() {
-
-    return new Promise(async (resolve, reject) => {
-      const processInstanceId = userTaskToFinishAfterTest.processInstanceId;
-      const userTaskId = userTaskToFinishAfterTest.flowNodeInstanceId;
-      const userTaskResult = {
-        formFields: {
-          Form_XGSVBgio: true,
-        },
-      };
-
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(userTaskToFinishAfterTest.processInstanceId, resolve);
-
-      await testFixtureProvider
-        .consumerApiClient
-        .finishUserTask(defaultIdentity, processInstanceId, userTaskToFinishAfterTest.correlationId, userTaskId, userTaskResult);
-    });
-  }
-
 });


### PR DESCRIPTION
## Changes

This removes the need for having a (possibly messy) cleanup after each test.
Instead, the fixture provider will now mob up all test data, after each test is done.

This allows all the tests to run with a completely clean setup.

## Issues

PR: #91

## How to test the changes

Run the tests.