### PR TITLE
♻️ Avoid unnecessary not found errors

### DIFF
--- a/_integration_tests/package.json
+++ b/_integration_tests/package.json
@@ -37,7 +37,7 @@
     "@essential-projects/http_extension": "~7.1.0",
     "@essential-projects/timing": "~5.0.0",
     "@process-engine/consumer_api_client": "~6.4.0",
-    "@process-engine/consumer_api_core": "feature~avoid_unnecessary_not_found_errors",
+    "@process-engine/consumer_api_core": "6.5.0-alpha.1",
     "@process-engine/consumer_api_http": "~5.5.1",
     "@process-engine/iam": "~1.7.1",
     "@process-engine/logging_api_core": "~2.0.0",

--- a/_integration_tests/package.json
+++ b/_integration_tests/package.json
@@ -37,7 +37,7 @@
     "@essential-projects/http_extension": "~7.1.0",
     "@essential-projects/timing": "~5.0.0",
     "@process-engine/consumer_api_client": "~6.4.0",
-    "@process-engine/consumer_api_core": "~6.4.1",
+    "@process-engine/consumer_api_core": "feature~avoid_unnecessary_not_found_errors",
     "@process-engine/consumer_api_http": "~5.5.1",
     "@process-engine/iam": "~1.7.1",
     "@process-engine/logging_api_core": "~2.0.0",

--- a/_integration_tests/test/correlation/get_correlation_results.js
+++ b/_integration_tests/test/correlation/get_correlation_results.js
@@ -69,7 +69,7 @@ describe('ConsumerAPI: GetProcessResultForCorrelation', () => {
 
     const correlationResults = results.correlationResults;
 
-    should(correlationResults).be.an.instanceOf(Array);
+    should(correlationResults).be.an.Array();
     should(correlationResults).have.a.lengthOf(1);
 
     const correlationResult = correlationResults[0];
@@ -98,7 +98,7 @@ describe('ConsumerAPI: GetProcessResultForCorrelation', () => {
 
     const correlationResults = results.correlationResults;
 
-    should(correlationResults).be.an.instanceOf(Array);
+    should(correlationResults).be.an.Array();
     should(correlationResults).have.a.lengthOf(2);
 
     const expectedResults = {
@@ -119,40 +119,36 @@ describe('ConsumerAPI: GetProcessResultForCorrelation', () => {
     }
   });
 
-  it('should fail to get the results, if the given correlationId does not exist', async () => {
+  it('should return an empty Array, if the given correlationId does not exist', async () => {
 
     const invalidCorrelationId = 'invalidCorrelationId';
 
-    try {
-      const results = await testFixtureProvider
-        .consumerApiClient
-        .getProcessResultForCorrelation(defaultIdentity, invalidCorrelationId, processModelIdDefault);
+    const results = await testFixtureProvider
+      .consumerApiClient
+      .getProcessResultForCorrelation(defaultIdentity, invalidCorrelationId, processModelIdDefault);
 
-      should.fail(results, undefined, 'This request should have failed!');
-    } catch (error) {
-      const expectedErrorCode = 404;
-      const expectedErrorMessage = /no process results for correlation.*?found/i;
-      should(error.message).be.match(expectedErrorMessage);
-      should(error.code).be.match(expectedErrorCode);
-    }
+    should(results).have.a.property('correlationResults');
+
+    const correlationResults = results.correlationResults;
+
+    should(correlationResults).be.an.Array();
+    should(correlationResults).be.empty();
   });
 
-  it('should fail to get the results, if the given process model id does not exist within the given correlation', async () => {
+  it('should return an empty Array, if the given process model id does not exist within the given correlation', async () => {
 
     const invalidprocessModelId = 'invalidprocessModelId';
 
-    try {
-      const results = await testFixtureProvider
-        .consumerApiClient
-        .getProcessResultForCorrelation(defaultIdentity, correlationId, invalidprocessModelId);
+    const results = await testFixtureProvider
+      .consumerApiClient
+      .getProcessResultForCorrelation(defaultIdentity, correlationId, invalidprocessModelId);
 
-      should.fail(results, undefined, 'This request should have failed!');
-    } catch (error) {
-      const expectedErrorCode = 404;
-      const expectedErrorMessage = /processmodel.*?not found/i;
-      should(error.message).be.match(expectedErrorMessage);
-      should(error.code).be.match(expectedErrorCode);
-    }
+    should(results).have.a.property('correlationResults');
+
+    const correlationResults = results.correlationResults;
+
+    should(correlationResults).be.an.Array();
+    should(correlationResults).be.empty();
   });
 
   it('should fail to get the results, when the user is unauthorized', async () => {

--- a/_integration_tests/test/empty_activities/get_waiting_for_correlation.js
+++ b/_integration_tests/test/empty_activities/get_waiting_for_correlation.js
@@ -53,7 +53,7 @@ describe('ConsumerAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(1);
 
       const emptyActivity = emptyActivityList.emptyActivities[0];
@@ -80,7 +80,7 @@ describe('ConsumerAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities.length).be.greaterThan(0);
 
       const emptyActivity = emptyActivityList.emptyActivities[0];
@@ -115,8 +115,8 @@ describe('ConsumerAPI: GetEmptyActivitiesForCorrelation', () => {
           .getEmptyActivitiesForCorrelation(defaultIdentity, processModelIdNoEmptyActivities);
 
         should(emptyActivityList).have.property('emptyActivities');
-        should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-        should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+        should(emptyActivityList.emptyActivities).be.an.Array();
+        should(emptyActivityList.emptyActivities).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -131,8 +131,8 @@ describe('ConsumerAPI: GetEmptyActivitiesForCorrelation', () => {
         .getEmptyActivitiesForCorrelation(defaultIdentity, invalidCorrelationId);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 
@@ -157,7 +157,7 @@ describe('ConsumerAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(5);
     });
 
@@ -169,7 +169,7 @@ describe('ConsumerAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(2);
     });
 
@@ -181,7 +181,7 @@ describe('ConsumerAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(2);
     });
 
@@ -193,7 +193,7 @@ describe('ConsumerAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(3);
     });
 
@@ -205,7 +205,7 @@ describe('ConsumerAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(10);
 
     });
@@ -218,8 +218,8 @@ describe('ConsumerAPI: GetEmptyActivitiesForCorrelation', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 
@@ -257,8 +257,8 @@ describe('ConsumerAPI: GetEmptyActivitiesForCorrelation', () => {
         .getEmptyActivitiesForCorrelation(restrictedIdentity, correlationId);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 });

--- a/_integration_tests/test/empty_activities/get_waiting_for_identity.js
+++ b/_integration_tests/test/empty_activities/get_waiting_for_identity.js
@@ -49,7 +49,7 @@ describe('ConsumerAPI: GetWaitingEmptyActivitiesByIdentity', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(1);
 
       const emptyActivity = emptyActivityList.emptyActivities[0];
@@ -74,8 +74,8 @@ describe('ConsumerAPI: GetWaitingEmptyActivitiesByIdentity', () => {
         .getWaitingEmptyActivitiesByIdentity(restrictedIdentity);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 
@@ -99,7 +99,7 @@ describe('ConsumerAPI: GetWaitingEmptyActivitiesByIdentity', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(5);
     });
 
@@ -111,7 +111,7 @@ describe('ConsumerAPI: GetWaitingEmptyActivitiesByIdentity', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(2);
     });
 
@@ -123,7 +123,7 @@ describe('ConsumerAPI: GetWaitingEmptyActivitiesByIdentity', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(2);
     });
 
@@ -135,7 +135,7 @@ describe('ConsumerAPI: GetWaitingEmptyActivitiesByIdentity', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(3);
     });
 
@@ -147,7 +147,7 @@ describe('ConsumerAPI: GetWaitingEmptyActivitiesByIdentity', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(10);
 
     });
@@ -160,8 +160,8 @@ describe('ConsumerAPI: GetWaitingEmptyActivitiesByIdentity', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 

--- a/_integration_tests/test/empty_activities/get_waiting_for_process_model.js
+++ b/_integration_tests/test/empty_activities/get_waiting_for_process_model.js
@@ -67,7 +67,7 @@ describe('ConsumerAPI: GetEmptyActivitiesForProcessModel', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(1);
 
       const emptyActivity = emptyActivityList.emptyActivities[0];
@@ -97,8 +97,8 @@ describe('ConsumerAPI: GetEmptyActivitiesForProcessModel', () => {
           .getEmptyActivitiesForProcessModel(defaultIdentity, processModelIdNoEmptyActivities);
 
         should(emptyActivityList).have.property('emptyActivities');
-        should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-        should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+        should(emptyActivityList.emptyActivities).be.an.Array();
+        should(emptyActivityList.emptyActivities).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -113,8 +113,8 @@ describe('ConsumerAPI: GetEmptyActivitiesForProcessModel', () => {
         .getEmptyActivitiesForProcessModel(defaultIdentity, invalidprocessModelId);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 
@@ -138,7 +138,7 @@ describe('ConsumerAPI: GetEmptyActivitiesForProcessModel', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(5);
     });
 
@@ -150,7 +150,7 @@ describe('ConsumerAPI: GetEmptyActivitiesForProcessModel', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(2);
     });
 
@@ -162,7 +162,7 @@ describe('ConsumerAPI: GetEmptyActivitiesForProcessModel', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(2);
     });
 
@@ -174,7 +174,7 @@ describe('ConsumerAPI: GetEmptyActivitiesForProcessModel', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(3);
     });
 
@@ -186,7 +186,7 @@ describe('ConsumerAPI: GetEmptyActivitiesForProcessModel', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(10);
 
     });
@@ -199,8 +199,8 @@ describe('ConsumerAPI: GetEmptyActivitiesForProcessModel', () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 
@@ -237,8 +237,8 @@ describe('ConsumerAPI: GetEmptyActivitiesForProcessModel', () => {
         .getEmptyActivitiesForProcessModel(restrictedIdentity, processModelId);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 });

--- a/_integration_tests/test/empty_activities/get_waiting_for_process_model_in_correlation.js
+++ b/_integration_tests/test/empty_activities/get_waiting_for_process_model_in_correlation.js
@@ -48,7 +48,7 @@ describe(`ConsumerAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(1);
 
       const emptyActivity = emptyActivityList.emptyActivities[0];
@@ -78,8 +78,8 @@ describe(`ConsumerAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => {
           .getEmptyActivitiesForProcessModel(defaultIdentity, processModelIdNoEmptyActivities);
 
         should(emptyActivityList).have.property('emptyActivities');
-        should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-        should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+        should(emptyActivityList.emptyActivities).be.an.Array();
+        should(emptyActivityList.emptyActivities).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -94,8 +94,8 @@ describe(`ConsumerAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => {
         .getEmptyActivitiesForProcessModelInCorrelation(defaultIdentity, invalidProcessModelId, correlationId);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
 
     it('should return an empty Array, if the correlationId does not exist', async () => {
@@ -107,8 +107,8 @@ describe(`ConsumerAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => {
         .getEmptyActivitiesForProcessModelInCorrelation(defaultIdentity, processModelId, invalidCorrelationId);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 
@@ -133,7 +133,7 @@ describe(`ConsumerAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(5);
     });
 
@@ -145,7 +145,7 @@ describe(`ConsumerAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(2);
     });
 
@@ -157,7 +157,7 @@ describe(`ConsumerAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(2);
     });
 
@@ -169,7 +169,7 @@ describe(`ConsumerAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(3);
     });
 
@@ -181,7 +181,7 @@ describe(`ConsumerAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
+      should(emptyActivityList.emptyActivities).be.an.Array();
       should(emptyActivityList.emptyActivities).have.a.lengthOf(10);
 
     });
@@ -194,8 +194,8 @@ describe(`ConsumerAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => {
 
       should(emptyActivityList).have.property('emptyActivities');
 
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 
@@ -232,8 +232,8 @@ describe(`ConsumerAPI: GetEmptyActivitiesForProcessModelInCorrelation`, () => {
         .getEmptyActivitiesForProcessModelInCorrelation(restrictedIdentity, processModelId, correlationId);
 
       should(emptyActivityList).have.property('emptyActivities');
-      should(emptyActivityList.emptyActivities).be.an.instanceOf(Array);
-      should(emptyActivityList.emptyActivities).have.a.lengthOf(0);
+      should(emptyActivityList.emptyActivities).be.an.Array();
+      should(emptyActivityList.emptyActivities).be.empty();
     });
   });
 });

--- a/_integration_tests/test/events/get_correlation_events.js
+++ b/_integration_tests/test/events/get_correlation_events.js
@@ -45,7 +45,7 @@ describe('ConsumerAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(1);
 
       eventList.events.forEach((event) => {
@@ -70,8 +70,8 @@ describe('ConsumerAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
 
     it('should return an empty Array, when the user has no access to any of the events', async () => {
@@ -86,8 +86,8 @@ describe('ConsumerAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
 
     });
   });
@@ -113,7 +113,7 @@ describe('ConsumerAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(5);
     });
 
@@ -125,7 +125,7 @@ describe('ConsumerAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(2);
     });
 
@@ -137,7 +137,7 @@ describe('ConsumerAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(2);
     });
 
@@ -149,7 +149,7 @@ describe('ConsumerAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(3);
     });
 
@@ -161,7 +161,7 @@ describe('ConsumerAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(10);
 
     });
@@ -174,8 +174,8 @@ describe('ConsumerAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 
@@ -211,8 +211,8 @@ describe('ConsumerAPI: GetEventsForCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 });

--- a/_integration_tests/test/events/get_correlation_process_model_events.js
+++ b/_integration_tests/test/events/get_correlation_process_model_events.js
@@ -45,7 +45,7 @@ describe('ConsumerAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events.length).be.greaterThan(0);
 
       eventList.events.forEach((event) => {
@@ -70,8 +70,8 @@ describe('ConsumerAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
 
     it('should return an empty Array, if the correlation_id does not exist', async () => {
@@ -84,8 +84,8 @@ describe('ConsumerAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 
@@ -110,7 +110,7 @@ describe('ConsumerAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(5);
     });
 
@@ -122,7 +122,7 @@ describe('ConsumerAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(2);
     });
 
@@ -134,7 +134,7 @@ describe('ConsumerAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(2);
     });
 
@@ -146,7 +146,7 @@ describe('ConsumerAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(3);
     });
 
@@ -158,7 +158,7 @@ describe('ConsumerAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(10);
 
     });
@@ -171,8 +171,8 @@ describe('ConsumerAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 
@@ -210,8 +210,8 @@ describe('ConsumerAPI: GetEventsForProcessModelInCorrelation', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 });

--- a/_integration_tests/test/events/get_process_model_events.js
+++ b/_integration_tests/test/events/get_process_model_events.js
@@ -56,7 +56,7 @@ describe('ConsumerAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events.length).be.greaterThan(0);
 
       eventList.events.forEach((event) => {
@@ -81,8 +81,8 @@ describe('ConsumerAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 
@@ -106,7 +106,7 @@ describe('ConsumerAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(5);
     });
 
@@ -118,7 +118,7 @@ describe('ConsumerAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(2);
     });
 
@@ -130,7 +130,7 @@ describe('ConsumerAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(2);
     });
 
@@ -142,7 +142,7 @@ describe('ConsumerAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(3);
     });
 
@@ -154,7 +154,7 @@ describe('ConsumerAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
+      should(eventList.events).be.an.Array();
       should(eventList.events).have.a.lengthOf(10);
 
     });
@@ -167,8 +167,8 @@ describe('ConsumerAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 
@@ -201,8 +201,8 @@ describe('ConsumerAPI: GetEventsForProcessModel', () => {
 
       should(eventList).have.property('events');
 
-      should(eventList.events).be.an.instanceOf(Array);
-      should(eventList.events).have.a.lengthOf(0);
+      should(eventList.events).be.an.Array();
+      should(eventList.events).be.empty();
     });
   });
 });

--- a/_integration_tests/test/external_tasks/fetch_and_lock.js
+++ b/_integration_tests/test/external_tasks/fetch_and_lock.js
@@ -42,7 +42,7 @@ describe('ConsumerAPI:   POST  ->  /external_tasks/fetch_and_lock', () => {
       .fetchAndLockExternalTasks(defaultIdentity, workerId, topicName, 1, 0, 10000);
 
     should(availableExternalTasks).be.an.Array();
-    should(availableExternalTasks).have.a.lengthOf(0);
+    should(availableExternalTasks).be.empty();
   });
 
   it('should successfully get a list of ExternalTasks that do not have any payloads', async () => {

--- a/_integration_tests/test/flow_node_instances/get_all_suspended.js
+++ b/_integration_tests/test/flow_node_instances/get_all_suspended.js
@@ -89,7 +89,7 @@ describe('ConsumerAPI: GetAllSuspendedTasks', () => {
         .getAllSuspendedTasks(defaultIdentity, 5);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(4);
     });
 
@@ -100,7 +100,7 @@ describe('ConsumerAPI: GetAllSuspendedTasks', () => {
         .getAllSuspendedTasks(defaultIdentity, 0, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(2);
     });
 
@@ -111,7 +111,7 @@ describe('ConsumerAPI: GetAllSuspendedTasks', () => {
         .getAllSuspendedTasks(defaultIdentity, 5, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(2);
     });
 
@@ -122,7 +122,7 @@ describe('ConsumerAPI: GetAllSuspendedTasks', () => {
         .getAllSuspendedTasks(defaultIdentity, 6, 5);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(3);
     });
 
@@ -133,7 +133,7 @@ describe('ConsumerAPI: GetAllSuspendedTasks', () => {
         .getAllSuspendedTasks(defaultIdentity, 0, 11);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(9);
     });
 
@@ -144,8 +144,8 @@ describe('ConsumerAPI: GetAllSuspendedTasks', () => {
         .getAllSuspendedTasks(defaultIdentity, 1000);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 
@@ -182,8 +182,8 @@ describe('ConsumerAPI: GetAllSuspendedTasks', () => {
         .getAllSuspendedTasks(restrictedIdentity);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/flow_node_instances/get_waiting_for_correlation.js
+++ b/_integration_tests/test/flow_node_instances/get_waiting_for_correlation.js
@@ -115,7 +115,7 @@ describe('ConsumerAPI: GetSuspendedTasksForCorrelation', () => {
 
         should(taskList).have.property('tasks');
         should(taskList.tasks).be.instanceOf(Array);
-        should(taskList.tasks).have.a.lengthOf(0);
+        should(taskList.tasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -131,7 +131,7 @@ describe('ConsumerAPI: GetSuspendedTasksForCorrelation', () => {
 
       should(taskList).have.property('tasks');
       should(taskList.tasks).be.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.empty();
     });
   });
 
@@ -155,7 +155,7 @@ describe('ConsumerAPI: GetSuspendedTasksForCorrelation', () => {
         .getSuspendedTasksForCorrelation(defaultIdentity, correlationIdPaginationTest, 4);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(5);
     });
 
@@ -166,7 +166,7 @@ describe('ConsumerAPI: GetSuspendedTasksForCorrelation', () => {
         .getSuspendedTasksForCorrelation(defaultIdentity, correlationIdPaginationTest, 0, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(2);
     });
 
@@ -177,7 +177,7 @@ describe('ConsumerAPI: GetSuspendedTasksForCorrelation', () => {
         .getSuspendedTasksForCorrelation(defaultIdentity, correlationIdPaginationTest, 5, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(2);
     });
 
@@ -188,7 +188,7 @@ describe('ConsumerAPI: GetSuspendedTasksForCorrelation', () => {
         .getSuspendedTasksForCorrelation(defaultIdentity, correlationIdPaginationTest, 6, 5);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(3);
     });
 
@@ -199,7 +199,7 @@ describe('ConsumerAPI: GetSuspendedTasksForCorrelation', () => {
         .getSuspendedTasksForCorrelation(defaultIdentity, correlationIdPaginationTest, 0, 11);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(9);
     });
 
@@ -210,8 +210,8 @@ describe('ConsumerAPI: GetSuspendedTasksForCorrelation', () => {
         .getSuspendedTasksForCorrelation(defaultIdentity, correlationIdPaginationTest, 1000);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 
@@ -248,8 +248,8 @@ describe('ConsumerAPI: GetSuspendedTasksForCorrelation', () => {
         .getSuspendedTasksForCorrelation(restrictedIdentity, correlationId);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/flow_node_instances/get_waiting_for_process_model.js
+++ b/_integration_tests/test/flow_node_instances/get_waiting_for_process_model.js
@@ -89,8 +89,8 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModel', () => {
           .getSuspendedTasksForProcessModel(defaultIdentity, processModelIdNoUserTasks);
 
         should(taskList).have.property('tasks');
-        should(taskList.tasks).be.an.instanceOf(Array);
-        should(taskList.tasks).have.a.lengthOf(0);
+        should(taskList.tasks).be.an.Array();
+        should(taskList.tasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -105,8 +105,8 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(defaultIdentity, invalidprocessModelId);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 
@@ -129,7 +129,7 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(defaultIdentity, processModelId, 4);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).has.a.lengthOf(5);
     });
 
@@ -140,7 +140,7 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(defaultIdentity, processModelId, 0, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).has.a.lengthOf(2);
     });
 
@@ -151,7 +151,7 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(defaultIdentity, processModelId, 5, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).has.a.lengthOf(2);
     });
 
@@ -162,7 +162,7 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(defaultIdentity, processModelId, 6, 5);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).has.a.lengthOf(3);
     });
 
@@ -173,7 +173,7 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(defaultIdentity, processModelId, 0, 11);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).has.a.lengthOf(9);
 
     });
@@ -185,8 +185,8 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(defaultIdentity, processModelId, 1000);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 
@@ -216,8 +216,8 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModel', () => {
         .getSuspendedTasksForProcessModel(restrictedIdentity, processModelId);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/flow_node_instances/get_waiting_for_process_model_in_correlation.js
+++ b/_integration_tests/test/flow_node_instances/get_waiting_for_process_model_in_correlation.js
@@ -76,8 +76,8 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
           .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelIdNoTasks, correlationId);
 
         should(taskList).have.property('tasks');
-        should(taskList.tasks).be.an.instanceOf(Array);
-        should(taskList.tasks).have.a.lengthOf(0);
+        should(taskList.tasks).be.an.Array();
+        should(taskList.tasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -92,8 +92,8 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, invalidProcessModelId, correlationId);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
 
     it('should return an empty Array, if the correlationId does not exist', async () => {
@@ -105,8 +105,8 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelId, invalidCorrelationId);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 
@@ -130,7 +130,7 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelId, correlationIdPaginationTest, 4);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(5);
     });
 
@@ -141,7 +141,7 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelId, correlationIdPaginationTest, 0, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(2);
     });
 
@@ -152,7 +152,7 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelId, correlationIdPaginationTest, 5, 2);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(2);
     });
 
@@ -163,7 +163,7 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelId, correlationIdPaginationTest, 6, 5);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(3);
     });
 
@@ -174,7 +174,7 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelId, correlationIdPaginationTest, 0, 11);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
+      should(taskList.tasks).be.an.Array();
       should(taskList.tasks).have.a.lengthOf(9);
     });
 
@@ -185,8 +185,8 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(defaultIdentity, processModelId, correlationIdPaginationTest, 1000);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 
@@ -223,8 +223,8 @@ describe('ConsumerAPI: GetSuspendedTasksForProcessModelInCorrelation', () => {
         .getSuspendedTasksForProcessModelInCorrelation(restrictedIdentity, processModelId, correlationId);
 
       should(taskList).have.property('tasks');
-      should(taskList.tasks).be.an.instanceOf(Array);
-      should(taskList.tasks).have.a.lengthOf(0);
+      should(taskList.tasks).be.an.Array();
+      should(taskList.tasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/get_process_models/get_process_model_by_id.js
+++ b/_integration_tests/test/get_process_models/get_process_model_by_id.js
@@ -51,8 +51,8 @@ describe('ConsumerAPI: GetProcessModelById', () => {
     should(processModel).have.property('id');
     should(processModel).have.property('startEvents');
     should(processModel).have.property('endEvents');
-    should(processModel.startEvents).have.a.lengthOf(0);
-    should(processModel.endEvents).have.a.lengthOf(0);
+    should(processModel.startEvents).be.empty();
+    should(processModel.endEvents).be.empty();
   });
 
   it('should fail to retrieve the process model, when the user is unauthorized', async () => {

--- a/_integration_tests/test/get_process_models/get_process_models.js
+++ b/_integration_tests/test/get_process_models/get_process_models.js
@@ -42,15 +42,15 @@ describe('ConsumerAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
       should(processModelList.processModels.length).be.greaterThan(0);
 
       processModelList.processModels.forEach((processModel) => {
         should(processModel).have.property('id');
         should(processModel).have.property('startEvents');
         should(processModel).have.property('endEvents');
-        should(processModel.startEvents).be.an.instanceOf(Array);
-        should(processModel.endEvents).be.an.instanceOf(Array);
+        should(processModel.startEvents).be.an.Array();
+        should(processModel.endEvents).be.an.Array();
       });
     });
 
@@ -64,15 +64,15 @@ describe('ConsumerAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
 
       processModelList.processModels.forEach((processModel) => {
         should(processModel).have.property('id');
         should(processModel.id).not.be.equal('test_consumer_api_process_start');
         should(processModel).have.property('startEvents');
         should(processModel).have.property('endEvents');
-        should(processModel.startEvents).be.an.instanceOf(Array);
-        should(processModel.endEvents).be.an.instanceOf(Array);
+        should(processModel.startEvents).be.an.Array();
+        should(processModel.endEvents).be.an.Array();
       });
     });
 
@@ -84,18 +84,18 @@ describe('ConsumerAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
 
       processModelList.processModels.forEach((processModel) => {
         should(processModel).have.property('id');
         should(processModel).have.property('startEvents');
         should(processModel).have.property('endEvents');
-        should(processModel.startEvents).be.an.instanceOf(Array);
-        should(processModel.endEvents).be.an.instanceOf(Array);
+        should(processModel.startEvents).be.an.Array();
+        should(processModel.endEvents).be.an.Array();
 
         if (processModel.id === 'test_consumer_api_non_executable_process') {
-          should(processModel.startEvents).have.a.lengthOf(0);
-          should(processModel.endEvents).have.a.lengthOf(0);
+          should(processModel.startEvents).be.empty();
+          should(processModel.endEvents).be.empty();
         }
       });
     });
@@ -128,7 +128,7 @@ describe('ConsumerAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
       should(processModelList.processModels).have.a.lengthOf(5);
     });
 
@@ -140,7 +140,7 @@ describe('ConsumerAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
       should(processModelList.processModels).have.a.lengthOf(2);
     });
 
@@ -152,7 +152,7 @@ describe('ConsumerAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
       should(processModelList.processModels).have.a.lengthOf(2);
     });
 
@@ -164,7 +164,7 @@ describe('ConsumerAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
       should(processModelList.processModels).have.a.lengthOf(3);
     });
 
@@ -176,7 +176,7 @@ describe('ConsumerAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
+      should(processModelList.processModels).be.an.Array();
       should(processModelList.processModels).have.a.lengthOf(10);
 
     });
@@ -189,8 +189,8 @@ describe('ConsumerAPI: GetProcessModels', () => {
 
       should(processModelList).have.property('processModels');
 
-      should(processModelList.processModels).be.an.instanceOf(Array);
-      should(processModelList.processModels).have.a.lengthOf(0);
+      should(processModelList.processModels).be.an.Array();
+      should(processModelList.processModels).be.empty();
     });
   });
 

--- a/_integration_tests/test/manual_tasks/get_waiting_for_correlation.js
+++ b/_integration_tests/test/manual_tasks/get_waiting_for_correlation.js
@@ -53,7 +53,7 @@ describe('ConsumerAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks.length).be.greaterThan(0);
 
       const manualTask = manualTaskList.manualTasks[0];
@@ -80,7 +80,7 @@ describe('ConsumerAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks.length).be.greaterThan(0);
 
       const manualTask = manualTaskList.manualTasks[0];
@@ -116,8 +116,8 @@ describe('ConsumerAPI: GetManualTasksForCorrelation', () => {
           .getManualTasksForCorrelation(defaultIdentity, processModelIdNoManualTasks);
 
         should(manualTaskList).have.property('manualTasks');
-        should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-        should(manualTaskList.manualTasks).have.a.lengthOf(0);
+        should(manualTaskList.manualTasks).be.an.Array();
+        should(manualTaskList.manualTasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -132,8 +132,8 @@ describe('ConsumerAPI: GetManualTasksForCorrelation', () => {
         .getManualTasksForCorrelation(defaultIdentity, invalidCorrelationId);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 
@@ -158,7 +158,7 @@ describe('ConsumerAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(5);
     });
 
@@ -170,7 +170,7 @@ describe('ConsumerAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(2);
     });
 
@@ -182,7 +182,7 @@ describe('ConsumerAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(2);
     });
 
@@ -194,7 +194,7 @@ describe('ConsumerAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(3);
     });
 
@@ -206,7 +206,7 @@ describe('ConsumerAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(10);
 
     });
@@ -219,8 +219,8 @@ describe('ConsumerAPI: GetManualTasksForCorrelation', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 
@@ -257,8 +257,8 @@ describe('ConsumerAPI: GetManualTasksForCorrelation', () => {
         .getManualTasksForCorrelation(restrictedIdentity, correlationId);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/manual_tasks/get_waiting_for_identity.js
+++ b/_integration_tests/test/manual_tasks/get_waiting_for_identity.js
@@ -49,7 +49,7 @@ describe('ConsumerAPI: GetWaitingManualTasksByIdentity', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks.length).be.greaterThan(0);
 
       const manualTask = manualTaskList.manualTasks[0];
@@ -74,8 +74,8 @@ describe('ConsumerAPI: GetWaitingManualTasksByIdentity', () => {
         .getWaitingManualTasksByIdentity(restrictedIdentity);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 
@@ -99,7 +99,7 @@ describe('ConsumerAPI: GetWaitingManualTasksByIdentity', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(5);
     });
 
@@ -111,7 +111,7 @@ describe('ConsumerAPI: GetWaitingManualTasksByIdentity', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(2);
     });
 
@@ -123,7 +123,7 @@ describe('ConsumerAPI: GetWaitingManualTasksByIdentity', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(2);
     });
 
@@ -135,7 +135,7 @@ describe('ConsumerAPI: GetWaitingManualTasksByIdentity', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(3);
     });
 
@@ -147,7 +147,7 @@ describe('ConsumerAPI: GetWaitingManualTasksByIdentity', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(10);
 
     });
@@ -160,8 +160,8 @@ describe('ConsumerAPI: GetWaitingManualTasksByIdentity', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 

--- a/_integration_tests/test/manual_tasks/get_waiting_for_process_model.js
+++ b/_integration_tests/test/manual_tasks/get_waiting_for_process_model.js
@@ -67,7 +67,7 @@ describe('ConsumerAPI: GetManualTasksForProcessModel', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks.length).be.greaterThan(0);
 
       const manualTask = manualTaskList.manualTasks[0];
@@ -97,8 +97,8 @@ describe('ConsumerAPI: GetManualTasksForProcessModel', () => {
           .getManualTasksForProcessModel(defaultIdentity, processModelIdNoManualTasks);
 
         should(manualTaskList).have.property('manualTasks');
-        should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-        should(manualTaskList.manualTasks).have.a.lengthOf(0);
+        should(manualTaskList.manualTasks).be.an.Array();
+        should(manualTaskList.manualTasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -113,8 +113,8 @@ describe('ConsumerAPI: GetManualTasksForProcessModel', () => {
         .getManualTasksForProcessModel(defaultIdentity, invalidprocessModelId);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 
@@ -138,7 +138,7 @@ describe('ConsumerAPI: GetManualTasksForProcessModel', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(5);
     });
 
@@ -150,7 +150,7 @@ describe('ConsumerAPI: GetManualTasksForProcessModel', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(2);
     });
 
@@ -162,7 +162,7 @@ describe('ConsumerAPI: GetManualTasksForProcessModel', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(2);
     });
 
@@ -174,7 +174,7 @@ describe('ConsumerAPI: GetManualTasksForProcessModel', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(3);
     });
 
@@ -186,7 +186,7 @@ describe('ConsumerAPI: GetManualTasksForProcessModel', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(10);
 
     });
@@ -199,8 +199,8 @@ describe('ConsumerAPI: GetManualTasksForProcessModel', () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 
@@ -230,8 +230,8 @@ describe('ConsumerAPI: GetManualTasksForProcessModel', () => {
         .getManualTasksForProcessModel(restrictedIdentity, processModelId);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/manual_tasks/get_waiting_for_process_model_in_correlation.js
+++ b/_integration_tests/test/manual_tasks/get_waiting_for_process_model_in_correlation.js
@@ -48,7 +48,7 @@ describe(`ConsumerAPI: GetManualTasksForProcessModelInCorrelation`, () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks.length).be.greaterThan(0);
 
       const manualTask = manualTaskList.manualTasks[0];
@@ -78,8 +78,8 @@ describe(`ConsumerAPI: GetManualTasksForProcessModelInCorrelation`, () => {
           .getManualTasksForProcessModel(defaultIdentity, processModelIdNoManualTasks);
 
         should(manualTaskList).have.property('manualTasks');
-        should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-        should(manualTaskList.manualTasks).have.a.lengthOf(0);
+        should(manualTaskList.manualTasks).be.an.Array();
+        should(manualTaskList.manualTasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -94,8 +94,8 @@ describe(`ConsumerAPI: GetManualTasksForProcessModelInCorrelation`, () => {
         .getManualTasksForProcessModelInCorrelation(defaultIdentity, invalidProcessModelId, correlationId);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
 
     it('should return an empty Array, if the correlationId does not exist', async () => {
@@ -107,8 +107,8 @@ describe(`ConsumerAPI: GetManualTasksForProcessModelInCorrelation`, () => {
         .getManualTasksForProcessModelInCorrelation(defaultIdentity, processModelId, invalidCorrelationId);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 
@@ -133,7 +133,7 @@ describe(`ConsumerAPI: GetManualTasksForProcessModelInCorrelation`, () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(5);
     });
 
@@ -145,7 +145,7 @@ describe(`ConsumerAPI: GetManualTasksForProcessModelInCorrelation`, () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(2);
     });
 
@@ -157,7 +157,7 @@ describe(`ConsumerAPI: GetManualTasksForProcessModelInCorrelation`, () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(2);
     });
 
@@ -169,7 +169,7 @@ describe(`ConsumerAPI: GetManualTasksForProcessModelInCorrelation`, () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(3);
     });
 
@@ -181,7 +181,7 @@ describe(`ConsumerAPI: GetManualTasksForProcessModelInCorrelation`, () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
+      should(manualTaskList.manualTasks).be.an.Array();
       should(manualTaskList.manualTasks).have.a.lengthOf(10);
 
     });
@@ -194,8 +194,8 @@ describe(`ConsumerAPI: GetManualTasksForProcessModelInCorrelation`, () => {
 
       should(manualTaskList).have.property('manualTasks');
 
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 
@@ -232,8 +232,8 @@ describe(`ConsumerAPI: GetManualTasksForProcessModelInCorrelation`, () => {
         .getManualTasksForProcessModelInCorrelation(restrictedIdentity, processModelId, correlationId);
 
       should(manualTaskList).have.property('manualTasks');
-      should(manualTaskList.manualTasks).be.an.instanceOf(Array);
-      should(manualTaskList.manualTasks).have.a.lengthOf(0);
+      should(manualTaskList.manualTasks).be.an.Array();
+      should(manualTaskList.manualTasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/process_instances/get_running_instances_for_identity.js
+++ b/_integration_tests/test/process_instances/get_running_instances_for_identity.js
@@ -51,7 +51,7 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
       should(results).have.a.property('processInstances');
       const processInstances = results.processInstances;
 
-      should(processInstances).be.an.instanceOf(Array);
+      should(processInstances).be.an.Array();
       should(processInstances.length).be.greaterThan(0);
 
       for (const processInstance of processInstances) {
@@ -75,8 +75,8 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
       should(results).have.a.property('processInstances');
       const processInstances = results.processInstances;
 
-      should(processInstances).be.an.instanceOf(Array);
-      should(processInstances).have.a.lengthOf(0);
+      should(processInstances).be.an.Array();
+      should(processInstances).be.empty();
     });
 
     it('should return an empty Array, if no accessible running ProcessInstances were found', async () => {
@@ -89,8 +89,8 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
 
       const processInstances = results.processInstances;
 
-      should(processInstances).be.an.instanceOf(Array);
-      should(processInstances).have.a.lengthOf(0);
+      should(processInstances).be.an.Array();
+      should(processInstances).be.empty();
     });
 
   });
@@ -115,7 +115,7 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
       should(results).have.a.property('processInstances');
       const processInstances = results.processInstances;
 
-      should(processInstances).be.an.instanceOf(Array);
+      should(processInstances).be.an.Array();
       should(processInstances).have.a.lengthOf(5);
     });
 
@@ -128,7 +128,7 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
       should(results).have.a.property('processInstances');
       const processInstances = results.processInstances;
 
-      should(processInstances).be.an.instanceOf(Array);
+      should(processInstances).be.an.Array();
       should(processInstances).have.a.lengthOf(2);
     });
 
@@ -141,7 +141,7 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
       should(results).have.a.property('processInstances');
       const processInstances = results.processInstances;
 
-      should(processInstances).be.an.instanceOf(Array);
+      should(processInstances).be.an.Array();
       should(processInstances).have.a.lengthOf(2);
     });
 
@@ -154,7 +154,7 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
       should(results).have.a.property('processInstances');
       const processInstances = results.processInstances;
 
-      should(processInstances).be.an.instanceOf(Array);
+      should(processInstances).be.an.Array();
       should(processInstances).have.a.lengthOf(3);
     });
 
@@ -167,7 +167,7 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
       should(results).have.a.property('processInstances');
       const processInstances = results.processInstances;
 
-      should(processInstances).be.an.instanceOf(Array);
+      should(processInstances).be.an.Array();
       should(processInstances).have.a.lengthOf(10);
 
     });
@@ -181,8 +181,8 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
       should(results).have.a.property('processInstances');
       const processInstances = results.processInstances;
 
-      should(processInstances).be.an.instanceOf(Array);
-      should(processInstances).have.a.lengthOf(0);
+      should(processInstances).be.an.Array();
+      should(processInstances).be.empty();
     });
   });
 

--- a/_integration_tests/test/user_tasks/get_waiting_for_correlation.js
+++ b/_integration_tests/test/user_tasks/get_waiting_for_correlation.js
@@ -53,7 +53,7 @@ describe('ConsumerAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks.length).be.greaterThan(0);
 
       const userTask = userTaskList.userTasks[0];
@@ -69,7 +69,7 @@ describe('ConsumerAPI: GetUserTasksForCorrelation', () => {
       should(userTask).not.have.property('identity');
 
       should(userTask.data).have.property('formFields');
-      should(userTask.data.formFields).be.an.instanceOf(Array);
+      should(userTask.data.formFields).be.an.Array();
       should(userTask.data.formFields).have.a.lengthOf(1);
 
       const formField = userTask.data.formFields[0];
@@ -92,7 +92,7 @@ describe('ConsumerAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks.length).be.greaterThan(0);
 
       const userTask = userTaskList.userTasks[0];
@@ -103,7 +103,7 @@ describe('ConsumerAPI: GetUserTasksForCorrelation', () => {
       should(userTask).have.property('data');
 
       should(userTask.data).have.property('formFields');
-      should(userTask.data.formFields).be.an.instanceOf(Array);
+      should(userTask.data.formFields).be.an.Array();
       should(userTask.data.formFields).have.a.lengthOf(1);
 
       const formField = userTask.data.formFields[0];
@@ -137,8 +137,8 @@ describe('ConsumerAPI: GetUserTasksForCorrelation', () => {
 
 
         should(userTaskList).have.property('userTasks');
-        should(userTaskList.userTasks).be.an.instanceOf(Array);
-        should(userTaskList.userTasks).have.a.lengthOf(0);
+        should(userTaskList.userTasks).be.an.Array();
+        should(userTaskList.userTasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -153,8 +153,8 @@ describe('ConsumerAPI: GetUserTasksForCorrelation', () => {
         .getUserTasksForCorrelation(defaultIdentity, invalidCorrelationId);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 
@@ -179,7 +179,7 @@ describe('ConsumerAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(5);
     });
 
@@ -191,7 +191,7 @@ describe('ConsumerAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(2);
     });
 
@@ -203,7 +203,7 @@ describe('ConsumerAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(2);
     });
 
@@ -215,7 +215,7 @@ describe('ConsumerAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(3);
     });
 
@@ -227,7 +227,7 @@ describe('ConsumerAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(10);
 
     });
@@ -240,8 +240,8 @@ describe('ConsumerAPI: GetUserTasksForCorrelation', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 
@@ -278,8 +278,8 @@ describe('ConsumerAPI: GetUserTasksForCorrelation', () => {
         .getUserTasksForCorrelation(restrictedIdentity, correlationId);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/user_tasks/get_waiting_for_identity.js
+++ b/_integration_tests/test/user_tasks/get_waiting_for_identity.js
@@ -49,7 +49,7 @@ describe('ConsumerAPI: GetWaitingUserTasksByIdentity', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks.length).be.greaterThan(0);
 
       const userTask = userTaskList.userTasks[0];
@@ -74,8 +74,8 @@ describe('ConsumerAPI: GetWaitingUserTasksByIdentity', () => {
         .getWaitingUserTasksByIdentity(restrictedIdentity);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 
@@ -99,7 +99,7 @@ describe('ConsumerAPI: GetWaitingUserTasksByIdentity', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(5);
     });
 
@@ -111,7 +111,7 @@ describe('ConsumerAPI: GetWaitingUserTasksByIdentity', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(2);
     });
 
@@ -123,7 +123,7 @@ describe('ConsumerAPI: GetWaitingUserTasksByIdentity', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(2);
     });
 
@@ -135,7 +135,7 @@ describe('ConsumerAPI: GetWaitingUserTasksByIdentity', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(3);
     });
 
@@ -147,7 +147,7 @@ describe('ConsumerAPI: GetWaitingUserTasksByIdentity', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(10);
 
     });
@@ -160,8 +160,8 @@ describe('ConsumerAPI: GetWaitingUserTasksByIdentity', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 

--- a/_integration_tests/test/user_tasks/get_waiting_for_process_model.js
+++ b/_integration_tests/test/user_tasks/get_waiting_for_process_model.js
@@ -67,7 +67,7 @@ describe('ConsumerAPI: GetUserTasksForProcessModel', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks.length).be.greaterThan(0);
 
       const userTask = userTaskList.userTasks[0];
@@ -83,7 +83,7 @@ describe('ConsumerAPI: GetUserTasksForProcessModel', () => {
       should(userTask).not.have.property('identity');
 
       should(userTask.data).have.property('formFields');
-      should(userTask.data.formFields).be.an.instanceOf(Array);
+      should(userTask.data.formFields).be.an.Array();
       should(userTask.data.formFields).have.a.lengthOf(1);
 
       const formField = userTask.data.formFields[0];
@@ -114,8 +114,8 @@ describe('ConsumerAPI: GetUserTasksForProcessModel', () => {
           .getUserTasksForProcessModel(defaultIdentity, processModelIdNoUserTasks);
 
         should(userTaskList).have.property('userTasks');
-        should(userTaskList.userTasks).be.an.instanceOf(Array);
-        should(userTaskList.userTasks).have.a.lengthOf(0);
+        should(userTaskList.userTasks).be.an.Array();
+        should(userTaskList.userTasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -130,8 +130,8 @@ describe('ConsumerAPI: GetUserTasksForProcessModel', () => {
         .getUserTasksForProcessModel(defaultIdentity, invalidprocessModelId);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 
@@ -155,7 +155,7 @@ describe('ConsumerAPI: GetUserTasksForProcessModel', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(5);
     });
 
@@ -167,7 +167,7 @@ describe('ConsumerAPI: GetUserTasksForProcessModel', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(2);
     });
 
@@ -179,7 +179,7 @@ describe('ConsumerAPI: GetUserTasksForProcessModel', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(2);
     });
 
@@ -191,7 +191,7 @@ describe('ConsumerAPI: GetUserTasksForProcessModel', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(3);
     });
 
@@ -203,7 +203,7 @@ describe('ConsumerAPI: GetUserTasksForProcessModel', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(10);
 
     });
@@ -216,8 +216,8 @@ describe('ConsumerAPI: GetUserTasksForProcessModel', () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 
@@ -254,8 +254,8 @@ describe('ConsumerAPI: GetUserTasksForProcessModel', () => {
         .getUserTasksForProcessModel(restrictedIdentity, processModelId);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 });

--- a/_integration_tests/test/user_tasks/get_waiting_for_process_model_in_correlation.js
+++ b/_integration_tests/test/user_tasks/get_waiting_for_process_model_in_correlation.js
@@ -48,7 +48,7 @@ describe(`ConsumerAPI: GetUserTasksForProcessModelInCorrelation`, () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks.length).be.greaterThan(0);
 
       const userTask = userTaskList.userTasks[0];
@@ -64,7 +64,7 @@ describe(`ConsumerAPI: GetUserTasksForProcessModelInCorrelation`, () => {
       should(userTask).not.have.property('identity');
 
       should(userTask.data).have.property('formFields');
-      should(userTask.data.formFields).be.an.instanceOf(Array);
+      should(userTask.data.formFields).be.an.Array();
       should(userTask.data.formFields).have.a.lengthOf(1);
 
       const formField = userTask.data.formFields[0];
@@ -90,8 +90,8 @@ describe(`ConsumerAPI: GetUserTasksForProcessModelInCorrelation`, () => {
           .getUserTasksForProcessModelInCorrelation(defaultIdentity, processModelIdNoUserTasks, correlationId);
 
         should(userTaskList).have.property('userTasks');
-        should(userTaskList.userTasks).be.an.instanceOf(Array);
-        should(userTaskList.userTasks).have.a.lengthOf(0);
+        should(userTaskList.userTasks).be.an.Array();
+        should(userTaskList.userTasks).be.empty();
 
         eventAggregator.publish('/processengine/process/signal/Continue', {});
       });
@@ -106,8 +106,8 @@ describe(`ConsumerAPI: GetUserTasksForProcessModelInCorrelation`, () => {
         .getUserTasksForProcessModelInCorrelation(defaultIdentity, invalidProcessModelId, correlationId);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
 
     it('should return an empty Array, if the correlationId does not exist', async () => {
@@ -119,8 +119,8 @@ describe(`ConsumerAPI: GetUserTasksForProcessModelInCorrelation`, () => {
         .getUserTasksForProcessModelInCorrelation(defaultIdentity, processModelId, invalidCorrelationId);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 
@@ -145,7 +145,7 @@ describe(`ConsumerAPI: GetUserTasksForProcessModelInCorrelation`, () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(5);
     });
 
@@ -157,7 +157,7 @@ describe(`ConsumerAPI: GetUserTasksForProcessModelInCorrelation`, () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(2);
     });
 
@@ -169,7 +169,7 @@ describe(`ConsumerAPI: GetUserTasksForProcessModelInCorrelation`, () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(2);
     });
 
@@ -181,7 +181,7 @@ describe(`ConsumerAPI: GetUserTasksForProcessModelInCorrelation`, () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(3);
     });
 
@@ -193,7 +193,7 @@ describe(`ConsumerAPI: GetUserTasksForProcessModelInCorrelation`, () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
+      should(userTaskList.userTasks).be.an.Array();
       should(userTaskList.userTasks).have.a.lengthOf(10);
 
     });
@@ -206,8 +206,8 @@ describe(`ConsumerAPI: GetUserTasksForProcessModelInCorrelation`, () => {
 
       should(userTaskList).have.property('userTasks');
 
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 
@@ -244,8 +244,8 @@ describe(`ConsumerAPI: GetUserTasksForProcessModelInCorrelation`, () => {
         .getUserTasksForProcessModelInCorrelation(restrictedIdentity, processModelId, correlationId);
 
       should(userTaskList).have.property('userTasks');
-      should(userTaskList.userTasks).be.an.instanceOf(Array);
-      should(userTaskList.userTasks).have.a.lengthOf(0);
+      should(userTaskList.userTasks).be.an.Array();
+      should(userTaskList.userTasks).be.empty();
     });
   });
 });


### PR DESCRIPTION
## Changes

1. Refactor tests for getting correlation results to expect an empty array instead of 404 errors, if no results were found
2. Improve usage of `should` assertions

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/550

PR: #102

## How to test the changes

Run the tests